### PR TITLE
Add dm-haiku to requirements and fix imports

### DIFF
--- a/data/chomsky_data_generator.py
+++ b/data/chomsky_data_generator.py
@@ -23,10 +23,10 @@ Github: https://github.com/google-deepmind/neural_networks_chomsky_hierarchy
 from typing import Any
 
 import jax
-from neural_networks_chomsky_hierarchy.experiments import constants as chomsky_constants
+from experiments import constants as chomsky_constants
 import numpy as np
 
-from neural_networks_solomonoff_induction.data import data_generator as dg_lib
+from data import data_generator as dg_lib
 
 
 # Delimiters are allocated in the last two feature dims of the one-hot vectors.

--- a/data/ctw_data_generator.py
+++ b/data/ctw_data_generator.py
@@ -22,7 +22,7 @@ from typing import Any, Sequence
 import jaxtyping as jtp
 import numpy as np
 
-from neural_networks_solomonoff_induction.data import data_generator as dg_lib
+from data import data_generator as dg_lib
 
 
 # Probability of spawning childrens from a node when creating CTW tree.

--- a/data/meta_data_generator.py
+++ b/data/meta_data_generator.py
@@ -21,7 +21,7 @@ This is used in particular in the paper to sample from multiple Chomsky tasks.
 from typing import Any, Sequence
 import numpy as np
 
-from neural_networks_solomonoff_induction.data import data_generator as dg_lib
+from data import data_generator as dg_lib
 
 
 class MetaDataGenerator(dg_lib.DataGenerator):

--- a/data/utm_data_generator.py
+++ b/data/utm_data_generator.py
@@ -22,8 +22,8 @@ import jax.nn as jnn
 import jax.numpy as jnp
 import numpy as np
 
-from neural_networks_solomonoff_induction.data import data_generator as dg_lib
-from neural_networks_solomonoff_induction.data import utms
+from data import data_generator as dg_lib
+from data import utms
 
 
 class Tokenizer(enum.IntEnum):

--- a/models/ctw.py
+++ b/models/ctw.py
@@ -36,7 +36,7 @@ from typing import Any, Union
 import jaxtyping as jtp
 import numpy as np
 
-from neural_networks_solomonoff_induction.data import data_generator as dg_lib
+from data import data_generator as dg_lib
 
 # The predictions are log-probabilities (natural logarithm) for the passed
 # sequences. It can either be marginal log-probabilities (i.e. log P(s) for all

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ jax
 jaxtyping
 numpy
 tqdm
+dm-haiku

--- a/train.py
+++ b/train.py
@@ -28,10 +28,10 @@ import optax
 import tqdm
 import tree
 
-from neural_networks_solomonoff_induction.data import data_generator as dg_lib
-from neural_networks_solomonoff_induction.data import utm_data_generator as utm_dg_lib
-from neural_networks_solomonoff_induction.data import utms as utms_lib
-from neural_networks_solomonoff_induction.models import transformer
+from data import data_generator as dg_lib
+from data import utm_data_generator as utm_dg_lib
+from data import utms as utms_lib
+from models import transformer
 
 
 def _make_loss_fn(model: hk.Transformed) -> Any:


### PR DESCRIPTION
Hello and thank you for this amazing research.
I'd like to congratulate you on high code quality.
I just had two minor errors trying to run this.
This PR fixes those two together, probably I should've separated them.
1) Fixing this
```
    import haiku as hk
ModuleNotFoundError: No module named 'haiku'
```
2) And also the imports have an extra prefix, For-example in train.py we have
`from neural_networks_solomonoff_induction.data import ...`
but if you `git clone` this repo and go to directory and `python train.py` you'll get errors.