### PR TITLE
Added a stream of random input symbols for a correct universal distribution sampling approximation

### DIFF
--- a/data/utms.py
+++ b/data/utms.py
@@ -260,6 +260,7 @@ class BrainPhoqueUTM(UniversalTuringMachine):
   Unlike the paper version, ',' is incuded and writes a uniformly random symbol to
   the work tape.
   Finally, outputs are returned with the instruction '.'.
+  See the reference above for more details.
 
   BrainPhoque (BP) differs slightly from BrainFuck (BF).
 


### PR DESCRIPTION
Sampling BP program is not equivalent to sampling from a universal distribution, because it is exponentially unlikely to sample long BP programs. As the instruction head moves right it will eventually enter an infinite loop. This means the probability of producing an M.L. random string is 0, which is NOT the case for the universal distribution (because it dominates the uniform distribution). This is a slightly informal statement since the set of M.L. random strings is not a cylinder set and the universal distribution is only a semi-measure, but it can be formalized. 

![image](https://github.com/google-deepmind/neural_networks_solomonoff_induction/assets/19755021/f3797f7f-66dc-43eb-8434-540f0a385058)

Correcting this error, I saw improved performance on transfer to VOMS for the large transformer model.
With the baseline:

![image](https://github.com/google-deepmind/neural_networks_solomonoff_induction/assets/19755021/c3deaecb-1d69-4d49-bbc2-e912b9102663)

![image](https://github.com/google-deepmind/neural_networks_solomonoff_induction/assets/19755021/97a3462a-cb0e-4e58-b2e2-cd0c5f034da0)


With this PR:

![image](https://github.com/google-deepmind/neural_networks_solomonoff_induction/assets/19755021/e183e1e3-3b54-4cee-b8ec-fdab7669c849)

![image](https://github.com/google-deepmind/neural_networks_solomonoff_induction/assets/19755021/14ec0eaa-f0df-4da2-a11f-13ccae517e7f)


Clearly performance is notably better, particularly on OOD sequence lengths. This is to be expected because VOMS produce sequences of unlimited Kolmogorov complexity and should require a source of random bits. 

My reproduction of the baseline doesn't quite reproduce paper results however; this is probably random variation since I trained only one model with one random seed (for each of baseline and this PR). Further testing may be advisable to verify that performance improves (and does not degrade on other tasks). 



